### PR TITLE
Fix uncaught error when "close()" is called without "open()" being called first

### DIFF
--- a/paper-alert-dialog.html
+++ b/paper-alert-dialog.html
@@ -111,8 +111,10 @@ Specification: [Material Design](http://www.google.es/design/spec/components/dia
 		close: function() {
 			this.$.dialog.close();
 
-			// Remove the dialog from the DOM
-			Polymer.dom(this.parentNode).removeChild(this);
+			// Remove dialog from the body if it is present in its local DOM
+			if(this.parentNode == document.body) {
+				Polymer.dom(document.body).removeChild(this);
+			}
 		},
 
 		// Private methods


### PR DESCRIPTION
When I was using this element in my web app I noticed that an error generates when the "close()" button is called when the dialog is open by setting the "opened" attribute to true or when calling "close()" when the dialog is already closed. To fix this I added a check to make sure that the node is inside the body DOM (where it is placed when "open()" is called) before attempting to remove the element.