### PR TITLE
Made demo compatible for all browsers

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 	<head>
-		<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../../iron-icons/iron-icons.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
@@ -55,17 +55,23 @@
 		</demo-snippet>
 
 		<script>
-			const dialogDemo = document.querySelector("#dialog-demo");
-			dialogDemo.openDialog = function(e) {
-				this.$.dialog.open();
-			};
-			dialogDemo.confirm = e => alert("Confirmed!");
-			dialogDemo.dismiss = e => alert("Dismissed!");
+			window.addEventListener('WebComponentsReady', function(e) {
+				const dialogDemo = document.querySelector("#dialog-demo");
+				dialogDemo.openDialog = function(e) {
+					this.$.dialog.open();
+				};
+				dialogDemo.confirm = function(e) {
+			      		alert("Confirmed!");
+				};
+			    	dialogDemo.dismiss = function(e) {
+			      		alert("Dismissed!");
+			    	};
 
-			const dialogWithHeaderDemo = document.querySelector("#dialog-with-header-demo");
-			dialogWithHeaderDemo.openDialogWithHeader = function(e) {
-				this.$.dialog.open();
-			};
+				const dialogWithHeaderDemo = document.querySelector("#dialog-with-header-demo");
+				dialogWithHeaderDemo.openDialogWithHeader = function(e) {
+					this.$.dialog.open();
+				};
+			});
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
I changed several things in the demo so that it worked in all modern browsers.  

1. Changed `webcomponents-loader.js` to `webcomponents-lite.js` since the first one is deprecated or at least does not work with Firefox
2. Added `WebComponentsReady` event listener for everything else except for Chrome and Opera are able to capture the element, otherwise it will get a `null` when the script tries to find the element in shadow DOM.
3. Changed ES6 function to ES5 for IE.
  
Here's the working demo with the exact fix: https://codepen.io/vaadin/pen/zjaRWw?editors=1000